### PR TITLE
Add bottom margin to contact page

### DIFF
--- a/contact/templates/contact.html
+++ b/contact/templates/contact.html
@@ -36,7 +36,7 @@
     </p>
     <p class="lh-m">Feel free to reach out to us.</p>
   </div>
-  <div class="container px-5 mx-2">
+  <div class="container px-5 mx-2 mb-5">
     <form method="POST" class="rounded" id="contact-us">
       {% csrf_token %} {{ form | crispy }}
       <button


### PR DESCRIPTION
- Added margin bottom to the bottom of the contact page for smaller devices to create space between the button and the footer.